### PR TITLE
Guarding against clojure.core/any?

### DIFF
--- a/src/commons/clojure/core.clj
+++ b/src/commons/clojure/core.clj
@@ -17,7 +17,8 @@
             such.types
             such.wide-domains
             such.wrongness
-            such.imperfection))
+            such.imperfection)
+  (:refer-clojure :exclude [any?]))
 
 
 ;;; Other people's code


### PR DESCRIPTION
Guarding against any?, which is part of clojure.core in 1.9.
